### PR TITLE
Added support for send simulate, changed recv-loop

### DIFF
--- a/lircsend.py
+++ b/lircsend.py
@@ -87,7 +87,7 @@ class LircSend:
 			buf = ""
 			data = ""
 			"""The socket caches IR recieve requests, we need to ignore them"""
-			while not data.startswith("BEGIN"):
+			while not "BEGIN" in data:
 				data = self._s.recv(256)
 				if self._debug:
 					print data
@@ -162,6 +162,10 @@ class LircSend:
 				command_dict[str(key)] = value
 			return command_dict
 		return None
+
+	def send_simulate(self, scancode, repeat, keysym, remote):
+		command = "SIMULATE {0:0>16x} {1:0>2d} {2:s} {3:s}".format(scancode, repeat, keysym, remote)
+		return self._send_packet(command)
 
 class LircResponse:
 	def __init__(self, command, success, payload):


### PR DESCRIPTION
Added the new function send_simulate.
irsend (the LIRC tool) have a mode called simulate where it could simulate received commands. This is useful for sending commands to LIRC.
The syntax looks like this:
    r = lirc_command_init(&cmd, "SIMULATE %016x %02x %s %s\n", scancode, repeat, keysym, remote);

Also changed the recv-loop to look for "BEGIN" in the whole data-string.
The first characters in data isn't always "BEGIN", it can contain newlines and other messages.
